### PR TITLE
Replace Trollop with Optimist dependency

### DIFF
--- a/bin/bumpy
+++ b/bin/bumpy
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 require 'rubygems'
-require 'trollop'
+require 'optimist'
 require 'bumpy'
 
-opts = Trollop::options do
+opts = Optimist::options do
   version "bumpy #{Bumpy::VERSION} by Hendrik Mans"
   banner <<-EOS
 Bumpy bumps your gem's version number.

--- a/bumpy.gemspec
+++ b/bumpy.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Bumpy::VERSION
 
-  gem.add_dependency 'trollop'
+  gem.add_dependency 'optimist'
 
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec'


### PR DESCRIPTION
The trollop gem has been renamed to "optimist".

See https://rubygems.org/gems/trollop/versions/2.9.10